### PR TITLE
fix: Enable semicolons by default

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,7 +2,7 @@
   "printWidth": 80,
   "tabWidth": 2,
   "useTabs": false,
-  "semi": false,
+  "semi": true,
   "singleQuote": true,
   "trailingComma": "es5",
   "bracketSpacing": false,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,8 +3,8 @@ import {wait} from './wait';
 
 async function run(): Promise<void> {
   try {
-    const ms: string = core.getInput('milliseconds')
-    core.debug(`Waiting ${ms} milliseconds ...`) // debug is only output if you set the secret `ACTIONS_STEP_DEBUG` to true
+    const ms: string = core.getInput('milliseconds');
+    core.debug(`Waiting ${ms} milliseconds ...`); // debug is only output if you set the secret `ACTIONS_STEP_DEBUG` to true
 
     core.debug(new Date().toTimeString());
     await wait(parseInt(ms, 10));
@@ -12,7 +12,7 @@ async function run(): Promise<void> {
 
     core.setOutput('time', new Date().toTimeString());
   } catch (error) {
-    if (error instanceof Error) core.setFailed(error.message)
+    if (error instanceof Error) core.setFailed(error.message);
   }
 }
 


### PR DESCRIPTION
This is our standard style everywhere else, right?